### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ npm run build
 - Improve loading states
 - Show movie trailers in a modal instead of a new page
 - Implement responsive design improvements
-- Load pages lazyly to improve performance
+- Load pages lazily to improve performance
 - Increase code coverage with unit and integration tests
 - Error handling and boundary error display
 


### PR DESCRIPTION
## Summary
- correct 'lazyly' to 'lazily' in the Next Steps section

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867127ef0648329863c195ca23cccb3