### PR TITLE
Add error test for fetchMovieById

### DIFF
--- a/src/lib/api/__tests__/tmdb.test.ts
+++ b/src/lib/api/__tests__/tmdb.test.ts
@@ -125,5 +125,20 @@ describe('TMDB API', () => {
       expect(result.data).toEqual(mockMovie);
       expect(result.error).toBeNull();
     });
+
+    it('should handle fetch errors', async () => {
+      // Mock failed response
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        text: async () => 'API Error',
+        statusText: 'Bad Request'
+      });
+
+      const result = await fetchMovieById('123');
+
+      // Assertions
+      expect(result.data).toBeNull();
+      expect(result.error).toBe('API Error');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- extend `fetchMovieById` tests to verify error handling

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68671abd30c88329b36d317ff0a86fd5