### PR TITLE
Fix loading state when movie id missing

### DIFF
--- a/src/components/MovieDetails/MovieDetails.tsx
+++ b/src/components/MovieDetails/MovieDetails.tsx
@@ -14,14 +14,17 @@ const MovieDetails = ({ id }: MovieDetailsProps) => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (id) {
-      fetchMovieById(id).then(({ data }) => {
-        if (data) {
-          setMovie(mapMovieDetailsToMovie(data));
-        }
-        setLoading(false);
-      });
+    if (!id) {
+      setLoading(false);
+      return;
     }
+
+    fetchMovieById(id).then(({ data }) => {
+      if (data) {
+        setMovie(mapMovieDetailsToMovie(data));
+      }
+      setLoading(false);
+    });
   }, [id]);
 
   const movieYear = useMemo(() => {


### PR DESCRIPTION
## Summary
- handle missing id in MovieDetails fetch effect

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867113af54c83299bfcf1105ad9e76d