### PR TITLE
Fix environment variable name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ cd my-movies
 cp .env.sample .env.local
 ```
 
-2. Update `.env.local` with your TMDB API token:
+2. Update `.env.local` with your TMDB API token (`VITE_TMDB_TOKEN`):
 ```
-TMDB_TOKEN=your_tmdb_api_token_here
+VITE_TMDB_TOKEN=your_tmdb_api_token_here
 ```
 
 ### Installation and Running


### PR DESCRIPTION
## Summary
- document `VITE_TMDB_TOKEN` in the setup instructions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68671d2815708329a7dc547b7aa6dc01